### PR TITLE
Using encodeURIComponent to encode password

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const openCatalog = require('./lib/OpenCatalog/service');
  * @class  Icecat
  */
 const icecat = function(login, password){
-    this.httpAuth = login + ':' + encodeURI(password);
+    this.httpAuth = login + ':' + encodeURIComponent(password);
     this.VERSION = 1;
     this.scheme = 'https://';
     this.httpUrl = 'data.icecat.biz/xml_s3/xml_server3.cgi';


### PR DESCRIPTION
encodeURI should be used to encode a complete URI. For individual components, encodeURIComponent should be used. A character in my password was causing problems before the change!