### PR TITLE
add getProductBySKU method

### DIFF
--- a/lib/OpenCatalog/service.js
+++ b/lib/OpenCatalog/service.js
@@ -39,6 +39,20 @@ openCatalog.prototype.getProductById = function(lang, productId) {
 };
 
 /**
+ * getProductBySKU
+ *
+ * Fetch product information by vendor + sku
+ *
+ * @param {string} lang
+ * @param {string} brand
+ * @param {string} sku
+ */
+openCatalog.prototype.getProductBySKU = function(lang, brand, sku) {
+  const httpRequestUrl = this._getBaseUrl(lang) + ';prod_id=' + sku + ';vendor=' + brand;
+
+  return this._requestProduct(httpRequestUrl);
+};
+/**
  * Create base url.
  *
  * @param {string} lang

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -60,6 +60,24 @@ test('getProductById calls correct url', (t) => {
   t.end();
 });
 
+test('getProductBySKU calls correct url', (t) => {
+  const sandbox = sinon.sandbox.create();
+  const service = new IcecatService(instance);
+  sandbox.stub(service, '_requestProduct');
+
+  const lang = 'EN';
+  const brand = 'hp';
+  const sku = 'RJ459AV';
+  service.getProductBySKU(lang, brand, sku);
+
+  const expectedUrl = service._getBaseUrl(lang) + ';prod_id=' + sku + ';vendor=' + brand;
+  const callArg = service._requestProduct.getCall(0).args[0];
+
+  t.is(callArg, expectedUrl);
+  sandbox.restore();
+  t.end();
+});
+
 test('Sets icecat to empty object if initialised with nothing', (t) => {
   const service = new IcecatService();
   t.deepEqual(service.icecat, {});


### PR DESCRIPTION
Added method to get product by vendor and vendor SKU. For example:

`  const info = await icecatClient.openCatalog.getProductBySKU('EN', 'hp', 'RJ459AV')`