### PR TITLE
Fix for issue #37 getImages() crash

### DIFF
--- a/lib/OpenCatalog/product.js
+++ b/lib/OpenCatalog/product.js
@@ -190,6 +190,7 @@ icecat.prototype.getEan = function() {
  * @returns {array}
  */
 icecat.prototype.getImages = function() {
+  this.productData.ProductGallery = this.productData.ProductGallery || [];
   if (!this.productData.ProductGallery.length || !this.productData.ProductGallery[0].ProductPicture.length) {
     return;
   }

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -276,6 +276,14 @@ test('Found - Product values - Images missing 2', (t) => {
 
   t.deepEqual(testProduct.getImages(), undefined);
 });
+
+test('Found - Product values - ProductGallery missing', (t) => {
+  const testProduct = new IcecatProduct(icecatProductJSONFound, icecatProductXMLFound, requestUrl);
+  delete testProduct.productData.ProductGallery;
+
+  t.deepEqual(testProduct.getImages(), undefined);
+});
+
 test('Found - Product values - Specifications', (t) => {
   const testProduct = new IcecatProduct(icecatProductJSONFound, icecatProductXMLFound, requestUrl);
   t.deepEqual(testProduct.getSpecifications(), [


### PR DESCRIPTION
I am making sure ProductGallery is an array, you could also validate that this array exists before using it.